### PR TITLE
decode parts of subject according to specified encoding

### DIFF
--- a/gmail/message.py
+++ b/gmail/message.py
@@ -130,7 +130,7 @@ class Message():
 
     def parse_subject(self, encoded_subject):
         dh = decode_header(encoded_subject)
-        return ''.join(t[0] for t in dh)
+        return ''.join(value.decode(encoding) for value, encoding in dh)
 
     def parse(self, raw_message):
         raw_headers = raw_message[0].decode()

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -130,7 +130,11 @@ class Message():
 
     def parse_subject(self, encoded_subject):
         dh = decode_header(encoded_subject)
-        return ''.join(value.decode(encoding) for value, encoding in dh)
+
+        # dh is a list that has (str, None) and (bytes, encoding) objects
+        return ''.join(
+            value.decode(encoding) if encoding else value
+            for value, encoding in dh)
 
     def parse(self, raw_message):
         raw_headers = raw_message[0].decode()


### PR DESCRIPTION
The `encoded subject` is a string like `=?ISO-8859-1?Q?a?= =?Latin-1?Q?b?=` which wraps pairs each chunk with its encoding. decode_headers returns the chunks with their encodings so instead of ignoring the encodings or treating them all as utf-8 (https://github.com/projectdelphai/gmail/pull/1), decode them with the specified encoding.